### PR TITLE
loadNpmTasks directive was pointing to wrong module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install grunt-js2coffee --save-dev
 Once that's done, add this line to your project's Gruntfile:
 
 ```js
-grunt.loadNpmTasks('js2coffee');
+grunt.loadNpmTasks('grunt-js2coffee');
 ```
 
 If the plugin has been installed correctly, running `grunt --help` at the command line should list the newly-installed plugin's task or tasks. In addition, the plugin should be listed in package.json as a `devDependency`, which ensures that it will be installed whenever the `npm install` command is run.


### PR DESCRIPTION
tasks are from gunt-js2coffee and not js2coffee

Just a typo in the read me encountered when integration your package.

Thanks for making this
